### PR TITLE
Implement initial FastAPI health endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: abatilo/actions-poetry@v2
+      - name: Install deps
+        run: poetry install --no-interaction
+      - name: Run tests
+        run: poetry run pytest -q
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run npm test
+        working-directory: frontend
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.env
+venv/
+node_modules/

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pulsepost-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "test": "echo \"No JS tests yet\""
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "pulsepost-ai"
+version = "0.1.0"
+description = "PulsePost AI Toolkit"
+authors = ["Your Name <you@example.com>"]
+packages = [{include = "backend"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "0.112.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "^8.0"
+httpx = "^0.27"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,12 @@
+import pytest
+from httpx import AsyncClient
+from fastapi import FastAPI
+
+from backend.app.main import app
+
+@pytest.mark.asyncio
+async def test_health_route_returns_ok():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- set up backend FastAPI app with a `/health` route
- add initial pytest for the health check
- configure a minimal Node frontend and npm test script
- add basic CI workflow running Poetry and npm tests
- add project metadata in `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test`