### PR TITLE
Fix backend Docker build path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.12-slim
 RUN pip install --no-cache-dir uv fastapi uvicorn
 
 WORKDIR /app
-COPY ../pyproject.toml ./pyproject.toml
-COPY . ./backend
+COPY pyproject.toml ./pyproject.toml
+COPY backend ./backend
 ENV PYTHONPATH=/app
 
 # Install dependencies using uv (fast, no-venv)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.9'
 services:
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     ports:
       - "8000:8000"
   frontend:


### PR DESCRIPTION
## Summary
- use repository root as build context so `pyproject.toml` can be copied
- update backend Dockerfile to reference correct paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent`