### PR TITLE
Implement LocalProvider and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
+
 on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -8,14 +10,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - uses: abatilo/actions-poetry@v2
-      - name: Install deps
-        run: poetry install --no-interaction
-      - name: Run tests
-        run: poetry run pytest -q
-      - uses: actions/setup-node@v4
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+      - name: Install backend deps
+        run: |
+          poetry install --no-interaction --no-root
+      - name: Run pytest
+        run: |
+          poetry run pytest -q
+      - name: Install Node
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Run npm test
-        working-directory: frontend
-        run: npm test
+      - name: npm install
+        run: |
+          cd frontend && npm install
+      - name: Run npm tests
+        run: |
+          cd frontend && npm test --silent
+      - name: Poetry check
+        run: |
+          poetry check

--- a/backend/llm_provider.py
+++ b/backend/llm_provider.py
@@ -1,0 +1,6 @@
+class LocalProvider:
+    """Simple local provider stub for tests."""
+
+    def generate(self, prompt: str) -> str:
+        """Return a canned response echoing the prompt."""
+        return f"pong:{prompt}"

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,8 @@
+from backend.llm_provider import LocalProvider
+
+
+def test_local_provider_returns_str():
+    provider = LocalProvider()
+    response = provider.generate("ping")
+    assert isinstance(response, str)
+    assert response.startswith("pong")


### PR DESCRIPTION
## Summary
- add LocalProvider stub and tests
- set up GitHub Actions workflow running python and node tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*