### PR TITLE
Implement OpenAI LLM provider

### DIFF
--- a/backend/llm_provider.py
+++ b/backend/llm_provider.py
@@ -1,6 +1,54 @@
+"""LLM provider abstraction layer."""
+
+from __future__ import annotations
+
+import os
+import httpx
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    """Application settings loaded from environment."""
+
+    OPENAI_API_KEY: str | None = None
+
+
+def get_settings() -> Settings:
+    """Return settings instance (factory for DI)."""
+
+    return Settings(OPENAI_API_KEY=os.getenv("OPENAI_API_KEY"))
+
+
 class LocalProvider:
     """Simple local provider stub for tests."""
 
     def generate(self, prompt: str) -> str:
         """Return a canned response echoing the prompt."""
         return f"pong:{prompt}"
+
+
+class OpenAIProvider:
+    """Call OpenAI API via HTTPX."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+
+    def generate(self, prompt: str) -> str:
+        api_key = self.settings.OPENAI_API_KEY
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY not configured")
+
+        headers = {"Authorization": f"Bearer {api_key}"}
+        payload = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        resp = httpx.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,8 @@
 import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 # Minimal asyncio marker support without pytest-asyncio
 

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,4 +1,16 @@
-from backend.llm_provider import LocalProvider
+import httpx
+from backend.llm_provider import LocalProvider, OpenAIProvider
+
+
+class DummyResp:
+    def __init__(self, data: str = "pong"):
+        self._data = data
+
+    def json(self):
+        return {"choices": [{"message": {"content": self._data}}]}
+
+    def raise_for_status(self):
+        pass
 
 
 def test_local_provider_returns_str():
@@ -6,3 +18,19 @@ def test_local_provider_returns_str():
     response = provider.generate("ping")
     assert isinstance(response, str)
     assert response.startswith("pong")
+
+
+def test_openai_provider_called_with_key(monkeypatch):
+    calls = {}
+
+    def fake_post(url, *, headers=None, json=None):
+        calls["headers"] = headers
+        calls["json"] = json
+        return DummyResp("bar")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(httpx, "post", fake_post, raising=False)
+    provider = OpenAIProvider()
+    result = provider.generate("hello")
+    assert result == "bar"
+    assert calls["headers"]["Authorization"] == "Bearer sk-test"


### PR DESCRIPTION
## Summary
- add OpenAI provider with simple env based settings
- allow tests to import repo modules without installing package
- cover OpenAI provider with test

## Testing
- `pytest -q`
- `npm test --silent`